### PR TITLE
Remove unnecessary checks for typeobject in function display

### DIFF
--- a/includes/AbstractTextContent.php
+++ b/includes/AbstractTextContent.php
@@ -217,9 +217,6 @@ class AbstractTextContent extends JsonContent {
 	public function getFunctionDisplayText($data, $zlang, $lang, $title_name) {
 		$result = "";
 		if (!array_key_exists('Z1K1', $data)) return NULL;
-		$typeobject = Helper::getZObject( $data['Z1K1'] );
-		if (is_null($typeobject)) return NULL;
-		if (!array_key_exists('Z4K2', $typeobject)) return NULL;
 
 		if (array_key_exists('Z8K2', $data)) {
 	  		$returntypezid = $data['Z8K2'];


### PR DESCRIPTION
This fixes the problem of return and argument types for functions not getting recorded in the import process.